### PR TITLE
refactor: Enhance home screen with shimmer, empty state, and list imp…

### DIFF
--- a/app/src/main/java/com/example/aroundegypt/features/home/presentation/HomeScreen.kt
+++ b/app/src/main/java/com/example/aroundegypt/features/home/presentation/HomeScreen.kt
@@ -1,17 +1,12 @@
 package com.example.aroundegypt.features.home.presentation
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
@@ -23,9 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -41,8 +34,11 @@ import com.example.aroundegypt.common.presentation.events.EventBus
 import com.example.aroundegypt.common.presentation.ui.theme.Gotham
 import com.example.aroundegypt.common.presentation.ui.theme.GothamRounded
 import com.example.aroundegypt.common.presentation.ui_components.HomeTopAppBar
-import com.example.aroundegypt.common.presentation.ui_components.ImageIcon
+import com.example.aroundegypt.features.home.domain.models.ExperiencesResponse
+import com.example.aroundegypt.features.home.presentation.ui_components.EmptyState
 import com.example.aroundegypt.features.home.presentation.ui_components.ExperienceCard
+import com.example.aroundegypt.features.home.presentation.ui_components.ExperienceList
+import com.example.aroundegypt.features.home.presentation.ui_components.ShimmerList
 import com.example.aroundegypt.features.home.presentation.ui_components.ShimmerListItem
 import kotlinx.serialization.Serializable
 
@@ -80,7 +76,7 @@ fun HomeScreenContent(
     state: HomeViewStates,
     drawerState: DrawerState,
     snackbarHostState: SnackbarHostState,
-    onLikeClick: (String) -> Unit,
+    onLikeClick: (ExperiencesResponse.Experience) -> Unit,
     onSearchQueryChange: (String) -> Unit,
     onSearchClick: () -> Unit,
 ) {
@@ -118,7 +114,7 @@ fun HomeScreenContent(
 private fun DefaultHomeState(
     contentPadding: PaddingValues,
     state: HomeViewStates,
-    onLikeClick: (String) -> Unit,
+    onLikeClick: (ExperiencesResponse.Experience) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier
@@ -165,29 +161,19 @@ private fun DefaultHomeState(
             )
         }
 
-        // LazyRow for Recommended Experiences
+        // Recommended Experiences List
         item {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                items(state.recommendedExperiences) { experience ->
-                    ShimmerListItem(isLoading = state.isLoading, contentAfterLoading = {
-                        ExperienceCard(
-                            modifier = Modifier.width(320.dp),
-                            experience = experience,
-                            isRecommended = true,
-                            onLikeClick = { onLikeClick(it) }
-                        )
-                    })
-                }
+            ShimmerList(state.isLoading)
+            if (!state.isLoading) {
+                ExperienceList(
+                    experiences = state.recommendedExperiences,
+                    isHorizontal = true,
+                    isRecommended = true,
+                    onLikeClick = onLikeClick
+                )
             }
         }
 
-        // Spacer
-        item {
-            Spacer(modifier = Modifier.height(10.dp))
-        }
 
         // Most Recent Text
         item {
@@ -199,23 +185,28 @@ private fun DefaultHomeState(
             )
         }
 
-        // LazyColumn for Most Recent Experiences
-        items(state.mostRecentExperiences) { experience ->
-            ShimmerListItem(isLoading = state.isLoading, contentAfterLoading = {
+        // Most Recent Experiences List
+        if (state.isLoading) {
+            items(5) {
+                ShimmerListItem()
+            }
+        } else {
+            items(state.mostRecentExperiences) { experience ->
                 ExperienceCard(
                     experience = experience,
                     modifier = Modifier.padding(end = 18.dp)
                 ) { onLikeClick(it) }
-            })
+            }
         }
     }
 }
+
 
 @Composable
 private fun SearchState(
     contentPadding: PaddingValues,
     state: HomeViewStates,
-    onLikeClick: (String) -> Unit
+    onLikeClick: (ExperiencesResponse.Experience) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier
@@ -224,42 +215,31 @@ private fun SearchState(
             .fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
+        // Show shimmer loading if data is loading
+        if (state.isLoading) {
+            items(5) {
+                ShimmerListItem()
+            }
+        }
+
+        // Show search results if available
         if (state.experiencesSearchResult.isNotEmpty()) {
             items(state.experiencesSearchResult) { experience ->
-                ShimmerListItem(isLoading = state.isLoading, contentAfterLoading = {
-                    ExperienceCard(
-                        experience = experience,
-                    ) { onLikeClick(it) }
-                })
+                ExperienceCard(
+                    experience = experience,
+                ) { onLikeClick(it) }
             }
-        } else if (state.isSearchPerformed && !state.isLoading) {
+        }
+
+        // Show empty state if no results and search is performed
+        else if (state.isSearchPerformed && !state.isLoading) {
             item {
-                Column(
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                EmptyState(
+                    iconResId = R.drawable.state_not_found,
+                    title = stringResource(R.string.not_found),
+                    message = stringResource(R.string.not_found_message),
                     modifier = Modifier.fillParentMaxSize()
-                ) {
-                    ImageIcon(
-                        icon = R.drawable.state_not_found,
-                        height = 200.dp,
-                        contentDescription = stringResource(
-                            R.string.not_found
-                        )
-                    )
-                    Text(
-                        text = stringResource(R.string.not_found),
-                        fontFamily = Gotham,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 18.sp
-                    )
-                    Text(
-                        text = stringResource(R.string.not_found_message),
-                        fontFamily = Gotham,
-                        fontWeight = FontWeight.Medium,
-                        fontSize = 14.sp,
-                        color = Color.LightGray
-                    )
-                }
+                )
             }
         }
 

--- a/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/EmptyState.kt
+++ b/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/EmptyState.kt
@@ -1,0 +1,47 @@
+package com.example.aroundegypt.features.home.presentation.ui_components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.aroundegypt.common.presentation.ui.theme.Gotham
+import com.example.aroundegypt.common.presentation.ui_components.ImageIcon
+
+@Composable
+fun EmptyState(
+    iconResId: Int,
+    title: String,
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+    ) {
+        ImageIcon(
+            icon = iconResId,
+            height = 200.dp,
+            contentDescription = title
+        )
+        Text(
+            text = title,
+            fontFamily = Gotham,
+            fontWeight = FontWeight.Bold,
+            fontSize = 18.sp
+        )
+        Text(
+            text = message,
+            fontFamily = Gotham,
+            fontWeight = FontWeight.Medium,
+            fontSize = 14.sp,
+            color = Color.LightGray
+        )
+    }
+}

--- a/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/ExperienceCard.kt
+++ b/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/ExperienceCard.kt
@@ -42,7 +42,7 @@ fun ExperienceCard(
     modifier: Modifier = Modifier,
     experience: ExperiencesResponse.Experience,
     isRecommended: Boolean = false,
-    onLikeClick: (String) -> Unit
+    onLikeClick: (ExperiencesResponse.Experience) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -60,9 +60,13 @@ fun ExperienceCard(
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                fontSize = 14.sp
+                fontSize = 14.sp,
+                modifier = Modifier.weight(2f)
             )
-            LikeExperience(experience = experience, onLikeClick = { onLikeClick(it) })
+            LikeExperience(
+                modifier = Modifier.weight(1f),
+                experience = experience,
+                onLikeClick = { onLikeClick(it) })
         }
     }
 }
@@ -93,12 +97,12 @@ private fun ExperienceImage(
             ConstraintLayout(modifier = Modifier.fillMaxSize()) {
                 val (recommendedBadge, infoIcon, viewsCount, imageIcon, viewIn360) = createRefs()
 
-                if (isRecommended)
                 // Recommended Badge
-                RecommendedBadge(modifier = Modifier.constrainAs(recommendedBadge) {
-                    top.linkTo(parent.top, margin = 10.dp)
-                    start.linkTo(parent.start, margin = 10.dp)
-                })
+                if (isRecommended)
+                    RecommendedBadge(modifier = Modifier.constrainAs(recommendedBadge) {
+                        top.linkTo(parent.top, margin = 10.dp)
+                        start.linkTo(parent.start, margin = 10.dp)
+                    })
 
                 // Info Icon
                 VectorIcon(
@@ -208,12 +212,12 @@ fun ViewsCount(modifier: Modifier = Modifier, viewsNo: Int) {
 fun LikeExperience(
     modifier: Modifier = Modifier,
     experience: ExperiencesResponse.Experience,
-    onLikeClick: (String) -> Unit
+    onLikeClick: (ExperiencesResponse.Experience) -> Unit
 ) {
-    Row {
+    Row(modifier = modifier, horizontalArrangement = Arrangement.End) {
         Text(
             text = "${experience.likesNo}",
-            modifier = modifier.padding(end = 10.dp),
+            modifier = Modifier.padding(end = 10.dp),
             fontFamily = Gotham,
             fontWeight = FontWeight.Medium,
             fontSize = 14.sp
@@ -223,8 +227,8 @@ fun LikeExperience(
             contentDescription = stringResource(
                 R.string.like
             ),
-            modifier = Modifier.clickable {
-                onLikeClick(experience.id)
+            modifier = Modifier.clickable(enabled = !experience.isLiked) {
+                onLikeClick(experience)
             })
     }
 }

--- a/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/ExperienceList.kt
+++ b/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/ExperienceList.kt
@@ -1,0 +1,49 @@
+package com.example.aroundegypt.features.home.presentation.ui_components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.aroundegypt.features.home.domain.models.ExperiencesResponse
+
+@Composable
+fun ExperienceList(
+    experiences: List<ExperiencesResponse.Experience>,
+    isHorizontal: Boolean = false,
+    isRecommended: Boolean = false,
+    onLikeClick: (ExperiencesResponse.Experience) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (isHorizontal) {
+        LazyRow(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(experiences) { experience ->
+                ExperienceCard(
+                    modifier = Modifier.width(320.dp),
+                    experience = experience,
+                    isRecommended = isRecommended,
+                    onLikeClick = { onLikeClick(it) }
+                )
+            }
+        }
+    } else {
+        LazyColumn(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(experiences) { experience ->
+                ExperienceCard(
+                    experience = experience,
+                    modifier = Modifier.padding(end = 18.dp)
+                ) { onLikeClick(it) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/ShimmerList.kt
+++ b/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/ShimmerList.kt
@@ -1,0 +1,32 @@
+package com.example.aroundegypt.features.home.presentation.ui_components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ShimmerList(
+    isLoading: Boolean = true,
+    itemCount: Int = 5,
+    isHorizontal: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    if (isLoading) {
+        if (isHorizontal) {
+            LazyRow(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                items(itemCount) {
+                    ShimmerListItem()
+                }
+            }
+        } else {
+            LazyColumn(modifier = modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                items(itemCount) {
+                    ShimmerListItem()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/ShimmerListItem.kt
+++ b/app/src/main/java/com/example/aroundegypt/features/home/presentation/ui_components/ShimmerListItem.kt
@@ -8,48 +8,54 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.aroundegypt.common.presentation.shimmer_effect_modifier.shimmerEffect
 
 @Composable
 fun ShimmerListItem(
-    isLoading: Boolean,
-    contentAfterLoading: @Composable () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .width(320.dp)
+                .height(164.dp)
+                .shimmerEffect()
+        )
 
-    if (isLoading) {
-        Column(
-            modifier = modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
+        Row(
+            modifier = Modifier.width(320.dp), horizontalArrangement = Arrangement.SpaceBetween
+        )
+        {
             Box(
                 modifier = Modifier
-                    .width(320.dp)
-                    .height(164.dp)
+                    .height(13.dp)
+                    .width(99.dp)
                     .shimmerEffect()
             )
-
             Row(
-                modifier = Modifier.width(300.dp), horizontalArrangement = Arrangement.SpaceBetween
-            )
-            {
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Box(
                     modifier = Modifier
                         .height(13.dp)
-                        .width(99.dp)
+                        .width(57.dp)
                         .shimmerEffect()
                 )
                 Box(
                     modifier = Modifier
-                        .height(18.dp)
-                        .width(57.dp)
+                        .height(13.dp)
+                        .width(13.dp)
                         .shimmerEffect()
                 )
             }
         }
-    } else {
-        contentAfterLoading()
+
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.1"
+agp = "8.8.2"
 constraintlayoutCompose = "1.1.1"
 kotlin = "2.0.20"
 coreKtx = "1.15.0"
@@ -8,7 +8,7 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
-composeBom = "2025.02.00"
+composeBom = "2025.03.00"
 converterGson = "2.11.0"
 hiltAndroidCompiler = "2.51.1"
 kotlinxSerializationJson = "1.8.0"
@@ -18,8 +18,7 @@ coilCompose = "3.1.0"
 ksp = "2.0.20-1.0.24"
 room = "2.6.1"
 hiltNavigationFragment = "1.2.0"
-navigationCompose = "2.8.8"
-shimmer = "1.0.0"
+navigationCompose = "2.8.9"
 [libraries]
 androidx-constraintlayout-compose = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayoutCompose" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
…rovements

- Added `ShimmerList` composable to display shimmer loading for both horizontal and vertical lists.
- Added `EmptyState` composable to display a message when no search results are found.
- Added `ExperienceList` composable to display a list of experiences, supporting both horizontal and vertical layouts.
- Implemented `ExperienceList` in `HomeScreen` to show the recommended and most recent experiences lists.
- Refactored `ShimmerListItem` to handle shimmer effect only, removed the `contentAfterLoading` parameter.
- Updated `SearchState` in `HomeScreen` to display the empty state using `EmptyState` composable.
- Refactored `DefaultHomeState` to use `ExperienceList` for displaying the most recent experiences and `ShimmerList` for shimmer loading.
- Modified `ExperienceCard` to display like button in `End` and adjust the text weight.
- Updated dependencies to latest versions: `agp` to 8.8.2, `composeBom` to 2025.03.00, `navigationCompose` to 2.8.9.