### PR TITLE
refactor: Improve handling of liked experiences and loading states in…

### DIFF
--- a/app/src/main/java/com/example/aroundegypt/features/home/domain/usecases/GetLikedExperiencesUC.kt
+++ b/app/src/main/java/com/example/aroundegypt/features/home/domain/usecases/GetLikedExperiencesUC.kt
@@ -1,10 +1,20 @@
 package com.example.aroundegypt.features.home.domain.usecases
 
+import com.example.aroundegypt.common.data.models.exception.AroundEgyptException
+import com.example.aroundegypt.common.data.models.state.Resource
 import com.example.aroundegypt.features.home.domain.models.Experience
 import com.example.aroundegypt.features.home.domain.repository.IExperiencesRepository
 
 class GetLikedExperiencesUC(private val repository: IExperiencesRepository) {
-    suspend operator fun invoke(): List<Experience> {
-        return repository.getLikedExperiences()
+    suspend operator fun invoke(): Resource<List<Experience>> {
+        return try {
+            Resource.Success(repository.getLikedExperiences())
+        } catch (e: Exception) {
+            val exception =
+                if (e is AroundEgyptException) e
+                else AroundEgyptException.UnknownException("Unknown error in GetExperienceFromLocalUC: $e")
+            Resource.Failure(exception)
+        }
     }
+
 }

--- a/app/src/main/java/com/example/aroundegypt/features/home/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/aroundegypt/features/home/presentation/screens/home/HomeViewModel.kt
@@ -50,8 +50,11 @@ class HomeViewModel @Inject constructor(
 
     private fun loadLikedExperiences() {
         viewModelScope.launch {
-            val savedLikedExperiences = getLikedExperiencesUC.invoke()
-            _state.update { it.copy(likedExperiences = savedLikedExperiences) }
+            when (val savedLikedExperiences = getLikedExperiencesUC.invoke()) {
+                is Resource.Failure -> handleError(savedLikedExperiences)
+                is Resource.Loading -> {}
+                is Resource.Success -> _state.update { it.copy(likedExperiences = savedLikedExperiences.data) }
+            }
         }
     }
 
@@ -62,24 +65,30 @@ class HomeViewModel @Inject constructor(
 
     fun reloadLikedExperiences() {
         viewModelScope.launch {
-            val savedLikedExperiences = getLikedExperiencesUC.invoke()
-            _state.update { currentState ->
-                currentState.copy(
-                    likedExperiences = savedLikedExperiences,
-                    recommendedExperiences = updateExperiencesWithLikedStatus(
-                        currentState.recommendedExperiences,
-                        savedLikedExperiences
-                    ),
-                    mostRecentExperiences = updateExperiencesWithLikedStatus(
-                        currentState.mostRecentExperiences,
-                        savedLikedExperiences
-                    ),
-                    experiencesSearchResult = updateExperiencesWithLikedStatus(
-                        currentState.experiencesSearchResult,
-                        savedLikedExperiences
-                    )
-                )
+            when (val savedLikedExperiences = getLikedExperiencesUC.invoke()) {
+                is Resource.Failure -> handleError(savedLikedExperiences)
+                is Resource.Loading -> {}
+                is Resource.Success -> {
+                    _state.update { currentState ->
+                        currentState.copy(
+                            likedExperiences = savedLikedExperiences.data,
+                            recommendedExperiences = updateExperiencesWithLikedStatus(
+                                currentState.recommendedExperiences,
+                                savedLikedExperiences.data
+                            ),
+                            mostRecentExperiences = updateExperiencesWithLikedStatus(
+                                currentState.mostRecentExperiences,
+                                savedLikedExperiences.data
+                            ),
+                            experiencesSearchResult = updateExperiencesWithLikedStatus(
+                                currentState.experiencesSearchResult,
+                                savedLikedExperiences.data
+                            )
+                        )
+                    }
+                }
             }
+
         }
     }
 


### PR DESCRIPTION
… `HomeViewModel`

- Updated `GetLikedExperiencesUC` to return a `Resource` to handle loading and error states.
- Modified `loadLikedExperiences` and `reloadLikedExperiences` in `HomeViewModel` to handle the `Resource` returned by `GetLikedExperiencesUC`, including error and loading states.
- Refactored `reloadLikedExperiences` to update the UI state based on the success, loading or failure of the liked experiences data retrieval.
- Updated `reloadLikedExperiences` to only update the state when the call to `getLikedExperiencesUC` was successful, and to pass the data not the resource to the ui.